### PR TITLE
feat: add color manupilations

### DIFF
--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -10,8 +10,13 @@ function downloadImage(req, res) {
         if(req?.width && req?.height) {
             image.resize(req.width, req.height, { fit: 'fill' })
         }
+
         if(req?.width || req?.height) {
             image.resize(req.width, req.height);
+        }
+        
+        if (req.greyscale){
+            image.greyscale();
         }
 
         res.setHeader('Content-Type', 'image/' + path.extname(req.image).substr(1));

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -29,6 +29,13 @@ router.param('height', (req, res, next, height) => {
     return next();
 });
 
+router.param('greyscale', (req, res, next, greyscale) => {
+    if (greyscale !== 'bw') return next('route');
+    req.greyscale = true;
+
+    return next();
+})
+
 router.head('/uploads/:image', (req, res) => {
     fs.access(req.localImagePath, fs.constants.R_OK, (err) => {
         res.status(err ? 404 : 200).end();
@@ -108,9 +115,13 @@ router.get(/\/thumbnail\.(jpg|png)/, (req, res, next) => {
     image.composite([{ input: thumbnail }]).toFormat(format).pipe(res);
 });
 
+router.get('/uploads/:width(\\d+)x:height(\\d+)-:greyscale-:image', downloadImage);
 router.get('/uploads/:width(\\d+)x:height(\\d+)-:image', downloadImage);
+router.get('/uploads/_x:height(\\d+)-:greyscale-:image', downloadImage);
 router.get('/uploads/_x:height(\\d+)-:image', downloadImage);
+router.get('/uploads/:width(\\d+)x_-:greyscale-:image', downloadImage);
 router.get('/uploads/:width(\\d+)x_-:image', downloadImage);
+router.get('/uploads/:greyscale-:image', downloadImage);
 router.get('/uploads/:image',downloadImage);
 
 module.exports = { router };


### PR DESCRIPTION
#### What does this PR do

- Adds image color manipulations

#### Tasks that support this implementation

- add `greyscale` image route and route parameter
- add a `greyscale` route `param middleware`
- update all existing download routes to take a `greyscale param`

#### Tests recorded for this feature / fix

- [ ] unit tests

- [ ] e2e tests

- [ ] integration tests

#### Steps to manually test this implementation

##### Development Environment setup

- clone the repository and run `cd imagx` to change to the project directory
- run `yarn install` command to install all the necessary dependencies
- run `yarn run dev` command to start the development server

##### Test Environment setup

- run `yarn test:e2e` command to run e2e tests
- run `yarn test:unit` command to run unit tests
- run `yarn test:integration` command to run integration tests
- run `yarn test` command to run all tests
- run `yarn test:coverage` command to run all tests with overall test coverage
