### PR TITLE
chore: refactor download middleware to use query strings

### DIFF
--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -6,20 +6,24 @@ function downloadImage(req, res) {
     fs.access(req.localImagePath, fs.constants.R_OK, (err) => {
         if (err) return res.status(404).end();
 
-        let image = sharp(req.localImagePath);
-        if(req?.width && req?.height) {
-            image.resize(req.width, req.height, { fit: 'fill' })
-        }
+        const image = sharp(req.localImagePath);
+        const width = +req?.query?.width;
+        const height = +req?.query?.height;
+        const greyscale = (['y', 'yes', '1'].includes(req?.query?.greyscale));
 
-        if(req?.width || req?.height) {
-            image.resize(req.width, req.height);
+        if (width > 0 && height > 0) {
+            image.resize(req.width, req.height, { fit: 'fill' });
+        };
+
+        if (width > 0 || height > 0) {
+            image.resize(width || null, height || null);
         }
         
-        if (req.greyscale){
+        if (greyscale){
             image.greyscale();
         }
 
-        res.setHeader('Content-Type', 'image/' + path.extname(req.image).substr(1));
+        res.setHeader('Content-Type', `image/${path.extname(req.image).substr(1)}`);
         image.pipe(res);
     });
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -115,13 +115,6 @@ router.get(/\/thumbnail\.(jpg|png)/, (req, res, next) => {
     image.composite([{ input: thumbnail }]).toFormat(format).pipe(res);
 });
 
-router.get('/uploads/:width(\\d+)x:height(\\d+)-:greyscale-:image', downloadImage);
-router.get('/uploads/:width(\\d+)x:height(\\d+)-:image', downloadImage);
-router.get('/uploads/_x:height(\\d+)-:greyscale-:image', downloadImage);
-router.get('/uploads/_x:height(\\d+)-:image', downloadImage);
-router.get('/uploads/:width(\\d+)x_-:greyscale-:image', downloadImage);
-router.get('/uploads/:width(\\d+)x_-:image', downloadImage);
-router.get('/uploads/:greyscale-:image', downloadImage);
 router.get('/uploads/:image',downloadImage);
 
 module.exports = { router };


### PR DESCRIPTION
#### What does this PR do

- Refactors thhe download middleware to use query strings

#### Tasks that support this implementation

- change the download middleware to check for query params as opposed to route params
- remove all the specific image download routes initially defined and use only one download route

#### Tests recorded for this feature / fix

- [ ] unit tests

- [ ] e2e tests

- [ ] integration tests

#### Steps to manually test this implementation

##### Development Environment setup

- clone the repository and run `cd imagx` to change to the project directory
- run `yarn install` command to install all the necessary dependencies
- run `yarn run dev` command to start the development server

##### Test Environment setup

- run `yarn test:e2e` command to run e2e tests
- run `yarn test:unit` command to run unit tests
- run `yarn test:integration` command to run integration tests
- run `yarn test` command to run all tests
- run `yarn test:coverage` command to run all tests with overall test coverage
